### PR TITLE
Set line widths to 1 to remove range error.

### DIFF
--- a/agi/test/polygon/index.vwf.yaml
+++ b/agi/test/polygon/index.vwf.yaml
@@ -63,7 +63,7 @@ children:
             flat: true
             translucent: false
             renderState:
-              lineWidth: 4.0
+              lineWidth: 1.0
   polygon:
     extends: http://vwf.example.com/cesium/geometry.vwf
     properties:
@@ -102,7 +102,7 @@ children:
             flat: true
             translucent: false
             renderState:
-              lineWidth: 4.0
+              lineWidth: 1.0
   ellipse:
     extends: http://vwf.example.com/cesium/geometry.vwf
     properties:
@@ -138,7 +138,7 @@ children:
             flat: true
             translucent: false
             renderState:
-              lineWidth: 4.0
+              lineWidth: 1.0
   circle:
     extends: http://vwf.example.com/cesium/geometry.vwf
     properties:
@@ -170,7 +170,7 @@ children:
             flat: true
             translucent: false
             renderState:
-              lineWidth: 4.0
+              lineWidth: 1.0
   extrudedRect:
     extends: http://vwf.example.com/cesium/geometry.vwf
     properties:
@@ -207,7 +207,7 @@ children:
             flat: true
             translucent: false
             renderState:
-              lineWidth: 4.0
+              lineWidth: 1.0
   extrudedEllipse:
     extends: http://vwf.example.com/cesium/geometry.vwf
     properties:
@@ -252,7 +252,7 @@ children:
             flat: true
             translucent: false
             renderState:
-              lineWidth: 4.0
+              lineWidth: 1.0
   extrudedPolygon:
     extends: http://vwf.example.com/cesium/geometry.vwf
     properties:
@@ -293,7 +293,7 @@ children:
             flat: true
             translucent: false
             renderState:
-              lineWidth: 4.0
+              lineWidth: 1.0
   cylinder:
     extends: http://vwf.example.com/cesium/geometry.vwf
     properties:
@@ -336,7 +336,7 @@ children:
             flat: true
             translucent: false
             renderState:
-              lineWidth: 4.0  
+              lineWidth: 1.0  
 #events:
 methods:
   createGeometry:  
@@ -403,7 +403,7 @@ scripts:
                   "flat": true,
                   "translucent": false,
                   "renderState": {
-                    "lineWidth": 2.0
+                    "lineWidth": 1.0
                   }
                 }
               }
@@ -469,7 +469,7 @@ scripts:
                   "flat": true,
                   "translucent": false,
                   "renderState": {
-                    "lineWidth": 2.0
+                    "lineWidth": 1.0
                   }
                 }
               }
@@ -535,7 +535,7 @@ scripts:
                   "flat": true,
                   "translucent": false,
                   "renderState": {
-                    "lineWidth": 2.0
+                    "lineWidth": 1.0
                   }
                 }
               }


### PR DESCRIPTION
@scottnc27603 

The polygon test app was throwing a range error on the renderScene lineWidth properties. Setting them back to 1 solves the error. However, perhaps it makes more sense to increase the context.maximumAliasedLineWidth to allow for values other than 1.

The range check is being performed in line 176 of /support/client/lib/vwf/model/cesium/Renderer/RenderState.js. 